### PR TITLE
feat: implement $sw (startsWith) operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "postinstall": "tsc",
     "prepublish": "tsc",
     "coverage": "c8 -r html tsx --test test/*.ts && open coverage/index.html",
-    "test": "c8 tsx --test test/*.ts"
+    "test": "c8 tsx --test test/*.ts",
+    "test:only": "c8 tsx --test --test-only test/*.ts"
   },
   "repository": {
     "type": "git",

--- a/test/query.ts
+++ b/test/query.ts
@@ -15,6 +15,17 @@ async function setupTestDb() {
   return db;
 }
 
+test('$sw operator on string', async () => {
+  const db = await setupTestDb();
+  await db.insert({ value: 'alpha' });
+  await db.insert({ value: 'beta' });
+  await db.insert({ value: 'chi' });
+  const result = await db.query({ value: { $sw: 'b' } });
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].value, 'beta');
+  await db.close();
+});
+
 test('$eq operator', async () => {
   const db = await setupTestDb();
   await db.insert({ value: 5 });


### PR DESCRIPTION
Implement the $sw (startsWith) operator.

```js
await db.insert({ value: 'alpha' });
await db.insert({ value: 'beta' });
await db.insert({ value: 'chi' });
const result = await db.query({ value: { $sw: 'b' } });
assert.strictEqual(result.length, 1);
assert.strictEqual(result[0].value, 'beta');
```