### PR TITLE
fix: nested field sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
       "license": "MIT",
       "dependencies": {
         "level": "^9.0.0",
-        "uuid": "^11.0.3"
+        "uuid": "^11.0.5"
       },
       "devDependencies": {
-        "@types/node": "^22.10.2",
+        "@types/node": "^22.13.1",
         "@types/uuid": "^10.0.0",
         "c8": "^10.1.3",
         "semistandard": "^17.0.0",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -753,9 +753,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4725,9 +4725,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4772,9 +4772,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doubledb",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doubledb",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubledb",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "type": "module",
   "description": "An on disk database that indexes everything for fast querying.",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
   },
   "homepage": "https://github.com/markwylde/doubledb#readme",
   "devDependencies": {
-    "@types/node": "^22.10.2",
+    "@types/node": "^22.13.1",
     "@types/uuid": "^10.0.0",
     "c8": "^10.1.3",
     "semistandard": "^17.0.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.3"
   },
   "dependencies": {
     "level": "^9.0.0",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -586,11 +586,16 @@ async function createDoubleDb(dataDirectory: string): Promise<DoubleDb> {
     if (options?.sort) {
       const sortFields = Object.entries(options.sort);
       results.sort((a, b) => {
-        for (const [field, direction] of sortFields) {
-          if (a[field] < b[field]) return direction === 1 ? -1 : 1;
-          if (a[field] > b[field]) return direction === 1 ? 1 : -1;
-        }
-        return 0;
+          for (const [field, direction] of sortFields) {
+              const aValue = field.split('.').reduce((obj, key) => obj[key], a);
+              const bValue = field.split('.').reduce((obj, key) => obj[key], b);
+
+              if (aValue < bValue)
+                return direction === 1 ? -1 : 1;
+              if (aValue > bValue)
+                return direction === 1 ? 1 : -1;
+          }
+          return 0;
       });
     }
 

--- a/test/query.ts
+++ b/test/query.ts
@@ -198,6 +198,33 @@ test('query limit, offset, sort', async () => {
   await db.close();
 });
 
+test('query sort with nested fields', async () => {
+  const db = await setupTestDb();
+  await db.insert({ value: { category: 2, name: 'B' } });
+  await db.insert({ value: { category: 1, name: 'A' } });
+  await db.insert({ value: { category: 1, name: 'C' } });
+  await db.insert({ value: { category: 2, name: 'D' } });
+
+  const result = await db.query({}, {
+    sort: {
+      'value.category': 1,
+      'value.name': 1
+    }
+  });
+
+  assert.strictEqual(result.length, 4);
+  assert.strictEqual(result[0].value.category, 1);
+  assert.strictEqual(result[0].value.name, 'A');
+  assert.strictEqual(result[1].value.category, 1);
+  assert.strictEqual(result[1].value.name, 'C');
+  assert.strictEqual(result[2].value.category, 2);
+  assert.strictEqual(result[2].value.name, 'B');
+  assert.strictEqual(result[3].value.category, 2);
+  assert.strictEqual(result[3].value.name, 'D');
+
+  await db.close();
+});
+
 test('query with sort option', async () => {
   const db = await setupTestDb();
   await db.insert({ value: 'gamma' });


### PR DESCRIPTION
# Add Support for Nested Field Sorting
- Enhanced the sorting functionality to support nested field paths in the sort options
- Updated dependencies to their latest versions
- Bumped package version to 3.4.1

## Details
The main enhancement in this PR is the ability to sort query results by nested object fields. Previously, sorting was only possible on top-level fields. Now you can sort using dot notation to access nested properties.

### Example
```javascript
// Now supports sorting by nested fields like this:
db.query({}, {
  sort: {
    'value.category': 1,
    'value.name': 1
  }
})
```

## Dependencies Updated
- @types/node: ^22.10.2 → ^22.13.1
- typescript: ^5.7.2 → ^5.7.3
- uuid: ^11.0.3 → ^11.0.5

## Breaking Changes
None - This is a backward-compatible enhancement