### PR TITLE
fix: remove error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -413,7 +413,7 @@ async function createDoubleDb(dataDirectory: string): Promise<DoubleDb> {
 
   async function remove(id: string): Promise<void> {
     if (!id) {
-      throw new Error('doubledb.remove: no id was supplied to replace function');
+      throw new Error('doubledb.remove: no id was supplied to remove function');
     }
 
     const existingDocument = await db.get(id)

--- a/test/index.ts
+++ b/test/index.ts
@@ -374,7 +374,7 @@ test('remove - missing id argument - throws', async () => {
     await db.remove(null);
   } catch (error) {
     await db.close();
-    assert.strictEqual((error as Error).message, 'doubledb.remove: no id was supplied to replace function');
+    assert.strictEqual((error as Error).message, 'doubledb.remove: no id was supplied to remove function');
   }
 });
 


### PR DESCRIPTION
## Summary
- correct the error message thrown when calling `remove` without an id
- update related test

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d59f2d2488327b672547df43f0fff