### PR TITLE
docs: use createDoubleDb in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ npm install --save doubledb
 
 ## Usage
 ```javascript
-import createDoubledb from 'doubledb';
-const doubledb = await createDoubledb('./data');
+import createDoubleDb from 'doubledb';
+const doubledb = await createDoubleDb('./data');
 
 // Insert a document
 await doubledb.insert({


### PR DESCRIPTION
## Summary
- update README usage snippet to use `createDoubleDb`

## Testing
- `npm test` *(fails: `c8` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d5a0c9f1c8327818d87f08cb9410f