### PR TITLE
Update insert error test

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -210,12 +210,12 @@ test('create - missing arguments - throws', async () => {
   await fs.rm(testDir, { recursive: true }).catch(() => {});
   const db = await createDoubleDb(testDir);
 
-  try {
-    await db.insert();
-  } catch (error) {
-    await db.close();
-    assert.strictEqual((error as Error).message, 'doubledb.insert: no document was supplied to insert function');
-  }
+  await assert.rejects(
+    db.insert(),
+    /doubledb.insert: no document was supplied to insert function/
+  );
+
+  await db.close();
 });
 
 test('replace - missing id argument - throws', async () => {


### PR DESCRIPTION
## Summary
- replace manual try/catch with `assert.rejects` in missing document test
- ensure DB closed after assertion

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d5a1665cc8327b02547e4151efefb